### PR TITLE
Pass a sequence to sqlite execute instead of single param

### DIFF
--- a/databaseCreate.py
+++ b/databaseCreate.py
@@ -26,8 +26,8 @@ def createDatabase(sqliteFile):
 		print(dbv)
 		
 		#add preset values
-		c.execute('''INSERT INTO databaseVersion  VALUES(?)''', (dbv)) # not working
-		
+		c.execute('''INSERT INTO databaseVersion  VALUES(?)''', [dbv]) # not working
+
 		print('inserted databaseVersion')
 		
 		conn.commit()


### PR DESCRIPTION
Hey Matthew,

It looks like the sqlite `connection.execute` expects a sequence to be passed as the second parameter instead of the single value. For example if you were inserting multiple values:
`c.execute('''INSERT INTO databaseVersion  VALUES(?,?)''', [dbv, another_value])`

So you need to wrap the dbv in `[]`
Hope that helps! 